### PR TITLE
Update content of README for github profile repository 0001

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,42 @@
-### Hi there 👋
+## Hi there, I'm Mark 👋
 
-- 🔭 I’m currently working on ...
+### I'm a Software Engineer with expertise in
 
-  To see what I'm currently working on, check out my
-  [Portfolio Overview Wiki](https://github.com/MarkWiltberger/portfolio-overview/wiki):   [HERE](https://github.com/MarkWiltberger/portfolio-overview/wiki).
+- TypeScript
+- JavaScript
+- Vue.js
+- Node.js
+- Nest.js
+- and other backend and frontend web application frameworks
 
-  There you will find I'm currently working on a proof-of-concept full-stack web app to handle transactions using the nest.js and vue.js frameworks.
+My current interests are writing backend and frontend for full-stack web apps and creating code that is maintainable, scalable, and testable.
 
-  [![rectangular nestjs logo](https://raw.githubusercontent.com/MarkWiltberger/MarkWiltberger/main/nestjs-ar21.svg)](https://nestjs.com/)
-  [![rectangular vuejs logo](https://raw.githubusercontent.com/MarkWiltberger/MarkWiltberger/main/vuejs-ar21.svg)](https://vuejs.org/)
+### Portfolio Website:
 
-<!--
-  ![nestjs-ar21](https://github.com/MarkWiltberger/MarkWiltberger/assets/17149108/afffb846-9622-4091-95d4-9bde9f01c419)
-  ![vuejs-ar21](https://github.com/MarkWiltberger/MarkWiltberger/assets/17149108/23689d2c-1e81-48ed-9799-88140b46b436)
--->
+My portfolio is written up in detail on my portfolio website:
 
-<!--
-![rectangular nestjs logo]([image.jpg](https://raw.githubusercontent.com/MarkWiltberger/MarkWiltberger/main/nestjs-ar21.svg))
-![rectangular vuejs logo]([image.jpg](https://raw.githubusercontent.com/MarkWiltberger/MarkWiltberger/main/vuejs-ar21.svg))
- -->
+<a href="https://markwiltberger.github.io" style="display: block; text-align: center; font-weight: bold;">
+    <img src="portfolio-webpage-visual-bookmark.jpeg" alt="portfolio webpage visual bookmark">
+</a>
+<a href="https://markwiltberger.github.io" style="display: block; text-align: center; font-weight: bold;">markwiltberger.github.io</a>
 
+<br>
 
-- 📫 How to reach me: ...
-  
+### The code here on GitHub for some of my portfolio projects are:
 
-  [![LinkedIn](https://raw.githubusercontent.com/MarkWiltberger/MarkWiltberger/main/linkedin-ar21.svg)](https://www.linkedin.com/in/mark-wiltberger-07438665/)
-  
+- [realtor-app repository](https://github.com/MarkWiltberger/vue-nest-web-app__realtor-app) - A Node.js/Nest.js backend for a mock realtor search website to search and create realty listings
+- [careers-search repository](https://github.com/MarkWiltberger/careers-search) - a Vue.js frontend for a mock career search website to search and filter job listings. A Work in Progress.
+- [markwiltberger.github.io repository](https://github.com/MarkWiltberger/markwiltberger.github.io) - my bio and portfolio website, built right here on GitHub using GitHub Pages.
 
-  [(LinkedIn)](https://www.linkedin.com/in/mark-wiltberger-07438665/)
+### Profile and Contact Information:
 
+- **My portfolio website:** <a href="https://markwiltberger.github.io" target="_blank">markwiltberger.github.io</a>
+- **My LinkedIn Profile:** <a href="https://www.linkedin.com/in/markwiltberger/" target="_blank">Mark Wiltberger on LinkedIn</a>
+- **email**: mark.wiltberger@gmail.com
+- **LinkedIn**: MarkWiltberger
 
+<br>
 
-<!--  [![LinkedIn](https://github.com/MarkWiltberger/MarkWiltberger/assets/17149108/d2be0153-35bd-4898-8cb8-c85b028c7e74)](https://www.linkedin.com/in/mark-wiltberger-07438665/) -->
+[![Readme Card](https://github-readme-stats.vercel.app/api?username=MarkWiltberger&show_icons=true&theme=vue-dark&hide=contribs&rank_icon=github&card_width=475)]
 
-
-  <!--  [![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg)](http://www.youtube.com/watch?v=YOUTUBE_VIDEO_ID_HERE) -->
-
-<!--  ![linkedin-ar21](https://github.com/MarkWiltberger/MarkWiltberger/assets/17149108/d2be0153-35bd-4898-8cb8-c85b028c7e74) -->
-<!--
-![rectangular LinkedIn logo]([image.jpg](https://raw.githubusercontent.com/MarkWiltberger/MarkWiltberger/main/linkedin-ar21.svg))
- -->
- 
-<!--
-**MarkWiltberger/MarkWiltberger** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-
-Here are some ideas to get you started:
-
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=MarkWiltberger&show_icons=true&theme=vue-dark&card_width=475)](https://github.com/anuraghazra/github-readme-stats)


### PR DESCRIPTION

- Closes #1 

Revamped the content and structure of the page and made references to the portfolio website, github repositories of active projects, and links to profile and contact information.